### PR TITLE
added stopping criteron in build fails

### DIFF
--- a/dev_scripts/run_jupyterlab.sh
+++ b/dev_scripts/run_jupyterlab.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 docker build -t jupyterlab-dev-img -f ./serve-jupyterlab/Dockerfile.test ./serve-jupyterlab
 python3 -m venv venv
 source ./venv/bin/activate

--- a/dev_scripts/run_mlflow.sh
+++ b/dev_scripts/run_mlflow.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 docker build -t mlflow-dev-img -f ./serve-mlflow/Dockerfile.test ./serve-mlflow
 python3 -m venv venv
 source ./venv/bin/activate

--- a/dev_scripts/run_rstudio.sh
+++ b/dev_scripts/run_rstudio.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 docker build -t rstudio-dev-img ./serve-rstudio
 python3 -m venv venv
 source ./venv/bin/activate

--- a/dev_scripts/run_tensorflow.sh
+++ b/dev_scripts/run_tensorflow.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 docker build -t serve-tensorflow-dev-img -f ./serve-tensorflow/Dockerfile.test ./serve-tensorflow
 python3 -m venv venv
 source ./venv/bin/activate

--- a/dev_scripts/run_torchserve.sh
+++ b/dev_scripts/run_torchserve.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -o errexit
+
 docker build -t torchserve-dev-img -f ./serve-torchserve/Dockerfile.test ./serve-torchserve
 python3 -m venv venv
 source ./venv/bin/activate


### PR DESCRIPTION
Just added a command to every `dev_script` such that it exits if any of the steps fail. I've encountered test failing and after 5-10 minutes reading logs I found that the container was never built, but the full script ran anyways. 
This is better i think. Agree?