### PR TITLE
Change uid to 1001 for serve

### DIFF
--- a/serve-vscode/Dockerfile
+++ b/serve-vscode/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 
-RUN useradd -m serve \
+RUN useradd -u 1001 -m serve \
     && mkdir -p /home/serve \
     && chown -R serve:serve /home/serve
 


### PR DESCRIPTION
Changing UID to 1001 for the user serve in vscode image as user 'ubuntu' is already with 1000. This creates a permission error as serve-chart is restricted to 1000.